### PR TITLE
Fix strl functions boundary checks

### DIFF
--- a/libs/libltdl/lt__strl.go
+++ b/libs/libltdl/lt__strl.go
@@ -5,6 +5,9 @@ func LtStrlcpy(dst []byte, src string, dstsize int) int {
 	if dstsize == 0 {
 		return len(src)
 	}
+	if dstsize > len(dst) {
+		return len(src)
+	}
 	n := copy(dst[:dstsize-1], src)
 	if n < dstsize {
 		dst[n] = 0
@@ -24,6 +27,9 @@ func LtStrlcat(dst []byte, src string, dstsize int) int {
 			break
 		}
 		length++
+	}
+	if dstsize > len(dst) {
+		return length + len(src)
 	}
 	if length >= dstsize {
 		return length + len(src)

--- a/libs/libltdl/lt__strl_test.go
+++ b/libs/libltdl/lt__strl_test.go
@@ -1,0 +1,52 @@
+package libltdl
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLtStrlcpyDstsizeExceedsSlice(t *testing.T) {
+	dst := make([]byte, 5)
+	n := LtStrlcpy(dst, "hello", 6)
+	if n != 5 {
+		t.Fatalf("expected length 5, got %d", n)
+	}
+	if !bytes.Equal(dst, make([]byte, 5)) {
+		t.Fatalf("dst modified when dstsize exceeds slice")
+	}
+}
+
+func TestLtStrlcatDstsizeExceedsSlice(t *testing.T) {
+	dst := []byte{'a', 0}
+	original := append([]byte(nil), dst...)
+	n := LtStrlcat(dst, "bc", 4)
+	if n != 3 {
+		t.Fatalf("expected length 3, got %d", n)
+	}
+	if !bytes.Equal(dst, original) {
+		t.Fatalf("dst modified when dstsize exceeds slice")
+	}
+}
+
+func TestLtStrlcpyNormal(t *testing.T) {
+	dst := make([]byte, 6)
+	n := LtStrlcpy(dst, "hello", 6)
+	if n != 5 {
+		t.Fatalf("expected length 5, got %d", n)
+	}
+	if string(dst[:5]) != "hello" || dst[5] != 0 {
+		t.Fatalf("unexpected dst contents: %v", dst)
+	}
+}
+
+func TestLtStrlcatNormal(t *testing.T) {
+	dst := []byte{'a', 0, 0, 0, 0}
+	n := LtStrlcat(dst, "bc", 5)
+	if n != 3 {
+		t.Fatalf("expected length 3, got %d", n)
+	}
+	want := []byte{'a', 'b', 'c', 0, 0}
+	if !bytes.Equal(dst, want) {
+		t.Fatalf("unexpected dst contents: %v", dst)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid panics when dstsize exceeds destination slice
- return string length without writing for oversized dstsize
- add tests for LtStrlcpy/LtStrlcat edge cases

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68613a397ec8832f9149fe51418f1420