### PR TITLE
Canonicalize module search paths

### DIFF
--- a/libs/libltdl/ltdl.go
+++ b/libs/libltdl/ltdl.go
@@ -17,41 +17,85 @@ type DlHandle struct {
 var userSearchPath []string
 
 // DlAddSearchDir appends dir to the module search path.
+// The path is canonicalized and duplicates are ignored.
 func DlAddSearchDir(dir string) int {
 	if dir == "" {
 		return 0
 	}
-	userSearchPath = append(userSearchPath, dir)
+	cdir, err := CanonicalizePath(dir)
+	if err != nil || cdir == "" {
+		return 0
+	}
+	for _, d := range userSearchPath {
+		if d == cdir {
+			return 0
+		}
+	}
+	userSearchPath = append(userSearchPath, cdir)
 	return 0
 }
 
 // DlInsertSearchDir inserts dir before the path element "before".
+// Both paths are canonicalized and duplicates are ignored.
 func DlInsertSearchDir(before, dir string) int {
 	if dir == "" {
 		return 0
 	}
+	cdir, err := CanonicalizePath(dir)
+	if err != nil || cdir == "" {
+		return 0
+	}
+	// Canonicalize the reference path as well
+	cbefore := before
+	if before != "" {
+		if b, err := CanonicalizePath(before); err == nil {
+			cbefore = b
+		}
+	}
+	for _, d := range userSearchPath {
+		if d == cdir {
+			return 0
+		}
+	}
 	idx := -1
 	for i, d := range userSearchPath {
-		if d == before {
+		if d == cbefore {
 			idx = i
 			break
 		}
 	}
 	if idx < 0 {
-		userSearchPath = append(userSearchPath, dir)
+		userSearchPath = append(userSearchPath, cdir)
 	} else {
-		userSearchPath = append(userSearchPath[:idx], append([]string{dir}, userSearchPath[idx:]...)...)
+		userSearchPath = append(userSearchPath[:idx], append([]string{cdir}, userSearchPath[idx:]...)...)
 	}
 	return 0
 }
 
 // DlSetSearchPath sets the module search path to the colon-separated list path.
+// Each entry is canonicalized and duplicates are dropped.
 func DlSetSearchPath(path string) int {
 	if path == "" {
 		userSearchPath = nil
 		return 0
 	}
-	userSearchPath = strings.Split(path, ":")
+	parts := strings.Split(path, ":")
+	seen := make(map[string]struct{})
+	userSearchPath = userSearchPath[:0]
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		c, err := CanonicalizePath(p)
+		if err != nil || c == "" {
+			continue
+		}
+		if _, ok := seen[c]; ok {
+			continue
+		}
+		seen[c] = struct{}{}
+		userSearchPath = append(userSearchPath, c)
+	}
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- avoid duplicates in libltdl search path handling
- canonicalize path entries when adding/inserting/setting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68613a36f120832f99fc82f2d6245191