### PR TITLE
Add RWMutex protection in libltdl

### DIFF
--- a/libs/libltdl/lock.go
+++ b/libs/libltdl/lock.go
@@ -1,0 +1,5 @@
+package libltdl
+
+import "sync"
+
+var mu sync.RWMutex

--- a/libs/libltdl/lt_dlloader.go
+++ b/libs/libltdl/lt_dlloader.go
@@ -35,6 +35,8 @@ func DlloaderAdd(vtable *Dlvtable) int {
 	if vtable.Priority != DlloaderPrepend && vtable.Priority != DlloaderAppend {
 		return 1
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if vtable.Priority == DlloaderPrepend {
 		loaders = append([]*Dlvtable{vtable}, loaders...)
 	} else {
@@ -46,6 +48,8 @@ func DlloaderAdd(vtable *Dlvtable) int {
 // DlloaderNext returns the index of the loader following loader.
 // Pass -1 to retrieve the first loader.
 func DlloaderNext(loader int) int {
+	mu.RLock()
+	defer mu.RUnlock()
 	if loader < 0 {
 		if len(loaders) > 0 {
 			return 0
@@ -60,6 +64,8 @@ func DlloaderNext(loader int) int {
 
 // DlloaderGet returns the vtable for loader index.
 func DlloaderGet(loader int) *Dlvtable {
+	mu.RLock()
+	defer mu.RUnlock()
 	if loader < 0 || loader >= len(loaders) {
 		return nil
 	}
@@ -68,6 +74,8 @@ func DlloaderGet(loader int) *Dlvtable {
 
 // DlloaderRemove removes and returns the loader with matching name.
 func DlloaderRemove(name string) *Dlvtable {
+	mu.Lock()
+	defer mu.Unlock()
 	for i, l := range loaders {
 		if l != nil && l.Name == name {
 			loaders = append(loaders[:i], loaders[i+1:]...)
@@ -79,6 +87,8 @@ func DlloaderRemove(name string) *Dlvtable {
 
 // DlloaderFind returns the first loader with matching name.
 func DlloaderFind(name string) *Dlvtable {
+	mu.RLock()
+	defer mu.RUnlock()
 	for _, l := range loaders {
 		if l != nil && l.Name == name {
 			return l
@@ -89,6 +99,7 @@ func DlloaderFind(name string) *Dlvtable {
 
 // DlloaderDump prints the list of loader names to stderr.
 func DlloaderDump() {
+	mu.RLock()
 	names := make([]string, 0, len(loaders))
 	for _, l := range loaders {
 		if l == nil {
@@ -100,6 +111,7 @@ func DlloaderDump() {
 		}
 		names = append(names, name)
 	}
+	mu.RUnlock()
 	if len(names) == 0 {
 		fmt.Fprintln(os.Stderr, "loaders: (empty)")
 	} else {

--- a/libs/libltdl/ltdl.go
+++ b/libs/libltdl/ltdl.go
@@ -21,7 +21,9 @@ func DlAddSearchDir(dir string) int {
 	if dir == "" {
 		return 0
 	}
+	mu.Lock()
 	userSearchPath = append(userSearchPath, dir)
+	mu.Unlock()
 	return 0
 }
 
@@ -30,6 +32,7 @@ func DlInsertSearchDir(before, dir string) int {
 	if dir == "" {
 		return 0
 	}
+	mu.Lock()
 	idx := -1
 	for i, d := range userSearchPath {
 		if d == before {
@@ -42,21 +45,28 @@ func DlInsertSearchDir(before, dir string) int {
 	} else {
 		userSearchPath = append(userSearchPath[:idx], append([]string{dir}, userSearchPath[idx:]...)...)
 	}
+	mu.Unlock()
 	return 0
 }
 
 // DlSetSearchPath sets the module search path to the colon-separated list path.
 func DlSetSearchPath(path string) int {
 	if path == "" {
+		mu.Lock()
 		userSearchPath = nil
+		mu.Unlock()
 		return 0
 	}
+	mu.Lock()
 	userSearchPath = strings.Split(path, ":")
+	mu.Unlock()
 	return 0
 }
 
 // DlGetSearchPath returns the current module search path as a colon-separated string.
 func DlGetSearchPath() string {
+	mu.RLock()
+	defer mu.RUnlock()
 	return strings.Join(userSearchPath, ":")
 }
 
@@ -187,7 +197,9 @@ func DlForeachFile(searchPath string, fn func(string, interface{}) int, data int
 	if searchPath != "" {
 		dirs = strings.Split(searchPath, ":")
 	} else {
-		dirs = userSearchPath
+		mu.RLock()
+		dirs = append([]string(nil), userSearchPath...)
+		mu.RUnlock()
 	}
 	for _, dir := range dirs {
 		entries, err := os.ReadDir(dir)

--- a/libs/libltdl/ltdl_basic.go
+++ b/libs/libltdl/ltdl_basic.go
@@ -20,7 +20,11 @@ func DlExit() int {
 		return 1
 	}
 	initialized = false
+	mu.Lock()
 	loaders = nil
 	userSearchPath = nil
+	defaultPreloaded = nil
+	preloadedLists = nil
+	mu.Unlock()
 	return 0
 }

--- a/libs/libltdl/ltdl_extra.go
+++ b/libs/libltdl/ltdl_extra.go
@@ -45,7 +45,10 @@ func DlOpenSearch(filename string, advise *DlAdvise) *DlHandle {
 			}
 		}
 	}
-	for _, dir := range userSearchPath {
+	mu.RLock()
+	dirs := append([]string(nil), userSearchPath...)
+	mu.RUnlock()
+	for _, dir := range dirs {
 		if dir == "" {
 			continue
 		}

--- a/libs/libltdl/preopen.go
+++ b/libs/libltdl/preopen.go
@@ -13,27 +13,36 @@ var (
 
 // DlPreloadDefault records preloaded symbols to be used by default.
 func DlPreloadDefault(preloaded []PreloadSym) int {
+	mu.Lock()
 	defaultPreloaded = preloaded
+	mu.Unlock()
 	return 0
 }
 
 // DlPreload adds preloaded symbols. Passing nil resets to the defaults.
 func DlPreload(preloaded []PreloadSym) int {
 	if preloaded == nil {
+		mu.Lock()
 		preloadedLists = nil
 		if defaultPreloaded != nil {
 			preloadedLists = append(preloadedLists, defaultPreloaded)
 		}
+		mu.Unlock()
 		return 0
 	}
+	mu.Lock()
 	preloadedLists = append(preloadedLists, preloaded)
+	mu.Unlock()
 	return 0
 }
 
 // DlPreloadOpen invokes cb for each module from originator.
 func DlPreloadOpen(originator string, cb func(*DlHandle) int) int {
+	mu.RLock()
+	lists := append([][]PreloadSym(nil), preloadedLists...)
+	mu.RUnlock()
 	var errors int
-	for _, list := range preloadedLists {
+	for _, list := range lists {
 		if len(list) == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary
- protect global state in libltdl with an RWMutex
- guard loaders, search path, and preload lists

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68613a3867ac832fae6257504278a5ac