### PR TITLE
Add Go slice-based vector and string wrappers

### DIFF
--- a/gostl/string.go
+++ b/gostl/string.go
@@ -1,0 +1,54 @@
+package gostl
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// String wraps a Vector[byte] providing helpers similar to the C++ String class.
+type String struct {
+	Vector[byte]
+}
+
+// NewString creates an empty String with the given capacity.
+func NewString(n int) *String {
+	return &String{Vector: *NewVector[byte](n)}
+}
+
+// AssignString replaces the string contents with s.
+func (s *String) AssignString(str string) {
+	s.Vector.Assign([]byte(str))
+}
+
+// AppendString appends a string to this String.
+func (s *String) AppendString(str string) {
+	s.Vector.AppendSlice([]byte(str))
+}
+
+// AppendRune appends r encoded as UTF-8.
+func (s *String) AppendRune(r rune) {
+	var buf [utf8.UTFMax]byte
+	n := utf8.EncodeRune(buf[:], r)
+	s.Vector.AppendSlice(buf[:n])
+}
+
+// AppendByte appends a single byte.
+func (s *String) AppendByte(b byte) { s.Vector.Append(b) }
+
+// MakeCString ensures the underlying buffer is null terminated without
+// affecting the logical length of the string.
+func (s *String) MakeCString() {
+	l := s.Size()
+	s.Reserve(l + 1)
+	s.data = s.data[:l+1]
+	s.data[l] = 0
+	s.data = s.data[:l]
+}
+
+// Formatf assigns the result of fmt.Sprintf to the string.
+func (s *String) Formatf(format string, a ...any) {
+	s.AssignString(fmt.Sprintf(format, a...))
+}
+
+// String returns the contents as a built-in string.
+func (s *String) String() string { return string(s.data) }

--- a/gostl/string_test.go
+++ b/gostl/string_test.go
@@ -1,0 +1,20 @@
+package gostl
+
+import "testing"
+
+func TestStringFormat(t *testing.T) {
+	s := NewString(0)
+	s.Formatf("%d-%s", 10, "test")
+	if s.String() != "10-test" {
+		t.Fatalf("unexpected formatted string %q", s.String())
+	}
+}
+
+func TestStringAppendRune(t *testing.T) {
+	s := NewString(0)
+	s.AppendRune('Æ')
+	s.MakeCString()
+	if got := string(s.Data()); got != "Æ" {
+		t.Fatalf("expected Æ, got %q", got)
+	}
+}

--- a/gostl/vector.go
+++ b/gostl/vector.go
@@ -1,0 +1,100 @@
+package gostl
+
+// Vector is a dynamically growable slice similar to the C++ Vector class.
+type Vector[T any] struct {
+	data []T
+}
+
+// NewVector allocates a Vector with the given size.
+func NewVector[T any](n int) *Vector[T] {
+	v := &Vector[T]{}
+	if n > 0 {
+		v.data = make([]T, n)
+	}
+	return v
+}
+
+// Data returns the underlying slice.
+func (v *Vector[T]) Data() []T { return v.data }
+
+// Size returns the number of elements stored in the vector.
+func (v *Vector[T]) Size() int { return len(v.data) }
+
+// Capacity returns the allocated capacity of the vector.
+func (v *Vector[T]) Capacity() int { return cap(v.data) }
+
+// Empty reports whether the vector is empty.
+func (v *Vector[T]) Empty() bool { return len(v.data) == 0 }
+
+// Clear removes all elements without releasing the buffer.
+func (v *Vector[T]) Clear() { v.data = v.data[:0] }
+
+// Resize changes the size of the vector, growing with zero values when needed.
+func (v *Vector[T]) Resize(n int) {
+	if n <= cap(v.data) {
+		if n <= len(v.data) {
+			v.data = v.data[:n]
+		} else {
+			extra := make([]T, n-len(v.data))
+			v.data = append(v.data, extra...)
+		}
+		return
+	}
+	v.reserveInternal(n)
+	v.data = v.data[:n]
+}
+
+func (v *Vector[T]) reserveInternal(n int) {
+	cap2 := cap(v.data)
+	if cap2 >= 10 {
+		cap2 *= 2
+	} else {
+		cap2 = 10
+	}
+	if n > cap2 {
+		cap2 = n
+	}
+	newData := make([]T, len(v.data), cap2)
+	copy(newData, v.data)
+	v.data = newData
+}
+
+// Reserve ensures that the vector has at least the given capacity.
+func (v *Vector[T]) Reserve(n int) {
+	if cap(v.data) < n {
+		v.reserveInternal(n)
+	}
+}
+
+// Append adds one element to the vector.
+func (v *Vector[T]) Append(elem T) {
+	v.Reserve(len(v.data) + 1)
+	v.data = append(v.data, elem)
+}
+
+// AppendSlice appends all elements from src to the vector.
+func (v *Vector[T]) AppendSlice(src []T) {
+	if len(src) == 0 {
+		return
+	}
+	v.Reserve(len(v.data) + len(src))
+	v.data = append(v.data, src...)
+}
+
+// Assign replaces the vector's content with a copy of src.
+func (v *Vector[T]) Assign(src []T) {
+	v.Resize(len(src))
+	copy(v.data, src)
+}
+
+// Swap exchanges the contents of two vectors.
+func (v *Vector[T]) Swap(other *Vector[T]) {
+	*v, *other = *other, *v
+}
+
+// Release returns the underlying slice and clears the vector.
+func (v *Vector[T]) Release() []T {
+	d := v.data
+	v.data = nil
+	return d
+}

--- a/gostl/vector_test.go
+++ b/gostl/vector_test.go
@@ -1,0 +1,19 @@
+package gostl
+
+import "testing"
+
+func TestVectorReserveResize(t *testing.T) {
+	var v Vector[int]
+	v.Reserve(5)
+	if v.Capacity() < 5 {
+		t.Fatalf("expected capacity >=5, got %d", v.Capacity())
+	}
+	v.Resize(3)
+	if v.Size() != 3 {
+		t.Fatalf("expected size 3, got %d", v.Size())
+	}
+	v.Resize(0)
+	if !v.Empty() {
+		t.Fatalf("expected empty vector")
+	}
+}


### PR DESCRIPTION
## Summary
- implement generic `Vector` type for dynamic slice management
- add `String` wrapper over `Vector[byte]` with rune append and formatting helpers
- include tests for reserve/resize and formatting

## Testing
- `go test ./...` *(fails: TestSearchPathHandling in libs/libltdl)*

------
https://chatgpt.com/codex/tasks/task_e_68613fe99288832faba04211f0e18fb8