### PR TITLE
Add Go memory helpers

### DIFF
--- a/libs/libtstlgo/alloc.go
+++ b/libs/libtstlgo/alloc.go
@@ -1,0 +1,42 @@
+package libtstl
+
+// Alloc returns a pointer to a new zero-value T.
+func Alloc[T any]() *T {
+	return new(T)
+}
+
+// AllocN allocates a zeroed slice of length n.
+func AllocN[T any](n int) []T {
+	if n <= 0 {
+		return nil
+	}
+	return make([]T, n)
+}
+
+// Grow resizes the slice to newLen, copying existing data.
+// It mimics realloc semantics: nil input allocates a new slice,
+// newLen <= 0 returns nil.
+func Grow[T any](s []T, newLen int) []T {
+	if newLen <= 0 {
+		return nil
+	}
+	if s == nil {
+		return make([]T, newLen)
+	}
+	if newLen <= cap(s) {
+		return s[:newLen]
+	}
+	t := make([]T, newLen)
+	copy(t, s)
+	return t
+}
+
+// Clone returns a copy of the provided slice.
+func Clone[T any](src []T) []T {
+	if src == nil {
+		return nil
+	}
+	dst := make([]T, len(src))
+	copy(dst, src)
+	return dst
+}


### PR DESCRIPTION
## Summary
- port basic alloc.cpp functionality to Go
- expose helpers for allocating and resizing typed slices
- support cloning slices

## Testing
- `go test ./...` *(fails: TestSearchPathHandling)*

------
https://chatgpt.com/codex/tasks/task_e_68613fe5dff8832f8111f359fd07f10d